### PR TITLE
403 Error when downloading config

### DIFF
--- a/download-config.py
+++ b/download-config.py
@@ -21,7 +21,11 @@ OP_NODE_P2P_STATIC={staticPeers}
 '''
 
 def fetch_data(api_path, slug):
-    with urllib.request.urlopen(f'{CONDUIT_API_URL}{api_path}{slug}') as response:
+    url = f'{CONDUIT_API_URL}{api_path}{slug}'
+    req = urllib.request.Request(
+        url,
+        headers={'User-Agent': 'Mozilla/5.0'}) # request is blocked with 403 unless specifying user agent
+    with urllib.request.urlopen(req) as response:
         return response.read()
 
 parser = argparse.ArgumentParser(description='Download Conduit Configs')


### PR DESCRIPTION
Currently if following the docs line by line it generates an error when trying to download the config files,

  File "/usr/local/anaconda3/lib/python3.12/urllib/request.py", line 639, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 403: Forbidden

Adding a user agent to the request is solving this issue.